### PR TITLE
add method: get

### DIFF
--- a/app/views/groups/_side_bar.html.haml
+++ b/app/views/groups/_side_bar.html.haml
@@ -10,7 +10,7 @@
         %i.fa.fa-cog
   .side-bar-under
     - current_user.groups.each do |group|
-      = link_to group_messages_path(group) do
+      = link_to group_messages_path(group), method: :get do
         .side-bar-under-group-name
           = group.name
         .side-bar-under-group-latest-message


### PR DESCRIPTION
【WHAT】
method: getを追加

【WHY】
method: getを省略するとページ遷移時にjsが作動しないため